### PR TITLE
更新弹幕内容正则匹配字符串

### DIFF
--- a/src/me/brucezz/crawler/handler/ResponseParser.java
+++ b/src/me/brucezz/crawler/handler/ResponseParser.java
@@ -20,7 +20,7 @@ public class ResponseParser {
     private static final String REGEX_SERVER = "%7B%22ip%22%3A%22(.*?)%22%2C%22port%22%3A%22(.*?)%22%7D%2C";
     private static final String REGEX_GROUP_ID = "type@=setmsggroup.*/rid@=(\\d*?)/gid@=(\\d*?)/";
     private static final String REGEX_DANMAKU_SERVER = "/ip@=(.*?)/port@=(\\d*?)/";
-    private static final String REGEX_CHAT_DANMAKU = "type@=chatmessage/.*/sender@=(\\d.*?)/content@=(.*?)/snick@=(.*?)/.*/rid@=(\\d*?)/";
+    private static final String REGEX_CHAT_DANMAKU = "type@=chatmsg/.*rid@=(\\d*)/.*uid@=(\\d*).*nn@=(.*?)/txt@=(.*?)/(.*)/";
 
 
     private static Matcher getMatcher(String content, String regex) {
@@ -120,10 +120,10 @@ public class ResponseParser {
         Danmaku danmaku = null;
 
         if (matcher.find()) {
-            danmaku = new Danmaku(Integer.parseInt(matcher.group(1)),
+            danmaku = new Danmaku(Integer.parseInt(matcher.group(2)),
                     matcher.group(3),
-                    matcher.group(2),
-                    Integer.parseInt(matcher.group(4)));
+                    matcher.group(4),
+                    Integer.parseInt(matcher.group(1)));
         }
 
         LogUtil.d("Parse Danmaku", danmaku + "");

--- a/src/me/brucezz/crawler/thread/CrawlerThread.java
+++ b/src/me/brucezz/crawler/thread/CrawlerThread.java
@@ -77,7 +77,7 @@ public class CrawlerThread implements Runnable {
             for (String response : responses) {
                 LogUtil.d("Receive Response", response);
 
-                if (!response.contains("chatmessage")) continue;
+                if (!response.contains("chatmsg")) continue;
 
                 //解析弹幕
                 Danmaku danmaku = ResponseParser.parseDanmaku(response);


### PR DESCRIPTION
最新的斗鱼弹幕格式变化，特修改正则表达式用于捕获弹幕。

```
type@=chatmsg/rid@=2761/uid@=5448527/nn@=着火的脸/txt@=以后MIYA的别墅就要这么造/cid@=14459195c10943b3cf85050000000000/level@=12/ct@=2/rg@=4/
```
